### PR TITLE
use navigate method because push creates duplicates

### DIFF
--- a/App.js
+++ b/App.js
@@ -68,19 +68,19 @@ function LeftHandNav({navigation}) {
   return (
     <View style={{flex: 1}}>
       <LHNHeader navigation={navigation} />
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 1})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 1})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_4.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat One</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 2})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 2})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_5.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat Two</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 3})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 3})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_3.png'}} />
         </View>

--- a/App.js
+++ b/App.js
@@ -316,7 +316,8 @@ export default class App extends React.Component {
                 <Stack.Screen
                   name="Chat"
                   component={ChatScreen}
-                  options={{headerShown: false}} />
+                  options={{headerShown: false}} 
+                  getId={({ params }) => params.id}/>
                 <Stack.Screen name="Search" component={SearchScreen} options={{headerShown: false}} />
                 <Stack.Screen name="SettingsStack" component={SettingsStackNavigator} options={{headerShown: false}} />
             </Stack.Navigator>


### PR DESCRIPTION
Clicking on the same chat report pushes the same route with the same params in the stack, which is redundant here.