### PR TITLE
Simplify the navigation to stack

### DIFF
--- a/App.js
+++ b/App.js
@@ -95,7 +95,7 @@ function AboutScreen({navigation}) {
     <WithCustomBackBehavior navigation={navigation}>
       <View style={{margin: 10}}>
         <View style={{marginBottom: 20, alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between'}}>
-          <Pressable onPress={() => navigation.pop()}>
+          <Pressable onPress={() => navigation.replace("Settings")}>
             <Image style={chevronStyle} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/chevron.png'}} />
           </Pressable>
           <Text style={titleStyle}>About</Text>
@@ -206,23 +206,24 @@ function ChatScreen({route, navigation}) {
         <Pressable
           onPress={() => {
             // This is fairly complex but seems to be the way we can "push" a new stack on and add the Settings screen in the routes
-            navigation.dispatch((state) => {
-              const newState = {...state};
-              const routes = [...newState.routes];
-              routes.push({
-                name: 'SettingsStack',
-                state: {
-                  index: 1,
-                  routes: [{name: 'Settings'}, {name: 'About'}]
-                }
-              });
-              const newestState = {
-                ...newState,
-                routes,
-                index: routes.length - 1,
-              };
-              return CommonActions.reset(newestState);
-            });
+            // navigation.dispatch((state) => {
+            //   const newState = {...state};
+            //   const routes = [...newState.routes];
+            //   routes.push({
+            //     name: 'SettingsStack',
+            //     state: {
+            //       index: 1,
+            //       routes: [{name: 'Settings'}, {name: 'About'}]
+            //     }
+            //   });
+            //   const newestState = {
+            //     ...newState,
+            //     routes,
+            //     index: routes.length - 1,
+            //   };
+            //   return CommonActions.reset(newestState);
+            // });
+            navigation.push('SettingsStack', { screen: 'About' });
           }}
         >
           <Text style={{color: 'blue', fontSize: 18, marginBottom: 10}}>Link to About</Text>

--- a/App.js
+++ b/App.js
@@ -116,15 +116,15 @@ function AboutScreen({navigation}) {
   );
 }
 
-function LHNHeader(props) {
+function LHNHeader({navigation}) {
   return (
     <View style={{marginBottom: 20, alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between'}}>
       <Text style={{fontSize: 24, fontWeight: 'bold', marginLeft: 10}}>Chats</Text>
       <View style={{flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-end', marginRight: 10, marginTop: 10}}>
-        <Pressable style={{marginRight: 20}} onPress={() => props.navigation.push('Search')}>
+        <Pressable style={{marginRight: 20}} onPress={() => navigation.push('Search')}>
           <Image style={{width: 30, height: 30}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/search.png'}} />
         </Pressable>
-        <Pressable onPress={() => props.navigation.push('SettingsStack')}>
+        <Pressable onPress={() => navigation.push('SettingsStack')}>
           <View style={{borderRadius: 22.5, overflow: 'hidden'}}>
             <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_3.png'}} />
           </View>
@@ -204,7 +204,7 @@ function ChatScreen({route, navigation}) {
           <Text style={{color: 'blue', fontSize: 18, marginBottom: 10}}>Link to another chat</Text>
         </Pressable>
         <Pressable
-          onPress={() => navigation.push('SettingsStack', { screen: 'About' })}
+          onPress={() => navigation.push('SettingsStack', { screen: 'About', initial: false })}
         >
           <Text style={{color: 'blue', fontSize: 18, marginBottom: 10}}>Link to About</Text>
         </Pressable>
@@ -297,16 +297,38 @@ export default class App extends React.Component {
                 <Stack.Screen
                   name="LeftHandNav"
                   component={LeftHandNav}
-                  options={{headerShown: false}}
+                  options={{
+                    headerShown: false,
+                    type: 'card'
+                  }}
                 />
                 <Stack.Screen
                   name="Chat"
                   component={ChatScreen}
-                  options={{headerShown: false}}
+                  options={{
+                    headerShown: false,
+                    type: 'card'
+                  }}
                   initialParams={{ id: 1 }} 
                   getId={({ params }) => params.id} />
-                <Stack.Screen name="Search" component={SearchScreen} options={{headerShown: false}} />
-                <Stack.Screen name="SettingsStack" component={SettingsStackNavigator} options={{headerShown: false}} />
+                <Stack.Group screenOptions={{ type: 'modal' }}>
+                  <Stack.Screen
+                    name="Search"
+                    component={SearchScreen}
+                    options={{
+                      headerShown: false,
+                      type: 'card'
+                    }}
+                  />
+                  <Stack.Screen
+                    name="SettingsStack"
+                    component={SettingsStackNavigator}
+                    options={{
+                      headerShown: false,
+                      type: 'card'
+                    }}
+                  />
+                </Stack.Group>
             </Stack.Navigator>
           </NavigationContainer>
         </View>

--- a/App.js
+++ b/App.js
@@ -68,19 +68,19 @@ function LeftHandNav({navigation}) {
   return (
     <View style={{flex: 1}}>
       <LHNHeader navigation={navigation} />
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 1})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 1})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_4.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat One</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 2})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 2})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_5.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat Two</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 3})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 3})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_3.png'}} />
         </View>
@@ -95,7 +95,7 @@ function AboutScreen({navigation}) {
     <WithCustomBackBehavior navigation={navigation}>
       <View style={{margin: 10}}>
         <View style={{marginBottom: 20, alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between'}}>
-          <Pressable onPress={() => navigation.replace("Settings")}>
+          <Pressable onPress={() => navigation.pop()}>
             <Image style={chevronStyle} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/chevron.png'}} />
           </Pressable>
           <Text style={titleStyle}>About</Text>
@@ -297,36 +297,23 @@ export default class App extends React.Component {
                 <Stack.Screen
                   name="LeftHandNav"
                   component={LeftHandNav}
-                  options={{
-                    headerShown: false,
-                    type: 'card'
-                  }}
+                  options={{ headerShown: false }}
                 />
                 <Stack.Screen
                   name="Chat"
                   component={ChatScreen}
-                  options={{
-                    headerShown: false,
-                    type: 'card'
-                  }}
-                  initialParams={{ id: 1 }} 
-                  getId={({ params }) => params.id} />
+                  options={{ headerShown: false }}
+                  initialParams={{ id: 1 }} />
                 <Stack.Group screenOptions={{ type: 'modal' }}>
                   <Stack.Screen
                     name="Search"
                     component={SearchScreen}
-                    options={{
-                      headerShown: false,
-                      type: 'card'
-                    }}
+                    options={{ headerShown: false }}
                   />
                   <Stack.Screen
                     name="SettingsStack"
                     component={SettingsStackNavigator}
-                    options={{
-                      headerShown: false,
-                      type: 'card'
-                    }}
+                    options={{ headerShown: false }}
                   />
                 </Stack.Group>
             </Stack.Navigator>

--- a/App.js
+++ b/App.js
@@ -68,19 +68,19 @@ function LeftHandNav({navigation}) {
   return (
     <View style={{flex: 1}}>
       <LHNHeader navigation={navigation} />
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 1})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 1})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_4.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat One</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 2})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 2})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_5.png'}} />
         </View>
         <Text style={chatTitleStyle}>Chat Two</Text>
       </Pressable>
-      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.push('Chat', {id: 3})}>
+      <Pressable style={{flexDirection: 'row', margin: 10, alignItems: 'center'}} onPress={() => navigation.navigate('Chat', {id: 3})}>
         <View style={{borderRadius: 22.5, overflow: 'hidden', marginRight: 10}}>
           <Image style={{width: 45, height: 45}} source={{uri: 'https://raw.githubusercontent.com/marcaaron/navigation-test/main/avatar_3.png'}} />
         </View>

--- a/App.js
+++ b/App.js
@@ -204,27 +204,7 @@ function ChatScreen({route, navigation}) {
           <Text style={{color: 'blue', fontSize: 18, marginBottom: 10}}>Link to another chat</Text>
         </Pressable>
         <Pressable
-          onPress={() => {
-            // This is fairly complex but seems to be the way we can "push" a new stack on and add the Settings screen in the routes
-            // navigation.dispatch((state) => {
-            //   const newState = {...state};
-            //   const routes = [...newState.routes];
-            //   routes.push({
-            //     name: 'SettingsStack',
-            //     state: {
-            //       index: 1,
-            //       routes: [{name: 'Settings'}, {name: 'About'}]
-            //     }
-            //   });
-            //   const newestState = {
-            //     ...newState,
-            //     routes,
-            //     index: routes.length - 1,
-            //   };
-            //   return CommonActions.reset(newestState);
-            // });
-            navigation.push('SettingsStack', { screen: 'About' });
-          }}
+          onPress={() => navigation.push('SettingsStack', { screen: 'About' })}
         >
           <Text style={{color: 'blue', fontSize: 18, marginBottom: 10}}>Link to About</Text>
         </Pressable>

--- a/App.js
+++ b/App.js
@@ -316,7 +316,8 @@ export default class App extends React.Component {
                 <Stack.Screen
                   name="Chat"
                   component={ChatScreen}
-                  options={{headerShown: false}} />
+                  options={{headerShown: false}} 
+                  getId={({ params }) => params.id}/>
                 <Stack.Screen name="Search" component={SearchScreen} options={{headerShown: false}} />
                 <Stack.Screen name="SettingsStack" component={SettingsStackNavigator} options={{headerShown: false}} />
             </Stack.Navigator>

--- a/App.js
+++ b/App.js
@@ -297,23 +297,23 @@ export default class App extends React.Component {
                 <Stack.Screen
                   name="LeftHandNav"
                   component={LeftHandNav}
-                  options={{ headerShown: false }}
+                  options={{headerShown: false}}
                 />
                 <Stack.Screen
                   name="Chat"
                   component={ChatScreen}
-                  options={{ headerShown: false }}
+                  options={{headerShown: false}}
                   initialParams={{ id: 1 }} />
-                <Stack.Group screenOptions={{ type: 'modal' }}>
+                <Stack.Group>
                   <Stack.Screen
                     name="Search"
                     component={SearchScreen}
-                    options={{ headerShown: false }}
+                    options={{headerShown: false}}
                   />
                   <Stack.Screen
                     name="SettingsStack"
                     component={SettingsStackNavigator}
-                    options={{ headerShown: false }}
+                    options={{headerShown: false}}
                   />
                 </Stack.Group>
             </Stack.Navigator>


### PR DESCRIPTION
1. Simplifying the navigation to nested navigator
2. Using `pop()` on the about page which will ensure we can go back to setting once navigated to the nested stack
3. Passing navigator directly and adding a `Stack.Group` for the Right hand modals - not really material changes just makes thing clearer imho